### PR TITLE
fix:CI환경과 로컬환경(Mac)의 LocalDateTime차이 에러 해결

### DIFF
--- a/src/main/java/org/example/honorsparkingbe/dto/request/ParkingZoneListRequest.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/request/ParkingZoneListRequest.java
@@ -22,5 +22,5 @@ public class ParkingZoneListRequest {
   @Max(value = 180, message = "경도는 180 이하이어야 합니다.")
   private Double longitude;
 
-  private Long page = 0L;  // 기본값을 설정
+  private Long page;  // 기본값을 설정
 }

--- a/src/test/java/org/example/honorsparkingbe/unit/repository/ParkingHistoryRepositoryTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/repository/ParkingHistoryRepositoryTest.java
@@ -1,5 +1,7 @@
 package org.example.honorsparkingbe.unit.repository;
 
+import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -8,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.example.honorsparkingbe.domain.entity.CarEntity;
 import org.example.honorsparkingbe.domain.entity.CityEntity;
@@ -205,7 +208,8 @@ public class ParkingHistoryRepositoryTest {
     assertEquals(null, nonDeletedHistory1.getDeleteAt());
     assertEquals(now, deleteHistory.getDeleteAt());
     assertNotEquals(preSoftDeletedHistory.getDeleteAt(), nonDeletedHistory1.getDeleteAt());
-
+    assertThat(deleteHistory.getDeleteAt())
+        .isCloseTo(now, within(100, ChronoUnit.MILLIS)); // 1/10초까지 허용
   }
 
   @Test


### PR DESCRIPTION
1. CI환경(Git action) 로컬환경(Mac)에서 불러오는 LocalDateTime의 정밀도가 다릅니다..!!
소수점 자리수 정밀도 차이때문에 로컬에서는 테.코가 돌아갔는데 CI환경에서는 안되네요

REF : https://jun27.tistory.com/72