### PR TITLE
fix: api-key filter test에서 property값 주입 방식 수정

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,13 +34,13 @@ jobs:
           echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/config/application.properties
 
       # application-test.yml 파일 생성
-  #      - name: application-test.yml 파일 만들기
-  #        run: |
-  #          mkdir -p ./src/test/resources/config
-  #          echo "${{ secrets.APPLICATION_TEST_YML }}" > ./src/test/resources/config/application-test.yml
-  #
-  #      - name: 테스트 및 빌드하기
-  #        run: ./gradlew clean build
+      #      - name: application-test.yml 파일 만들기
+      #        run: |
+      #          mkdir -p ./src/test/resources/config
+      #          echo "${{ secrets.APPLICATION_TEST_YML }}" > ./src/test/resources/config/application-test.yml
+      #
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build
   check-branch-up-to-date:
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,9 @@ tasks.named('test') {
 
 test {
     systemProperty 'spring.profiles.active', 'test'
+
+    testLogging {
+        events "failed" // ✅ 실패한 테스트만
+        showStandardStreams = true // ✅ System.out.println 포함 출력
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -76,11 +76,15 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+//test {
+//    systemProperty 'spring.profiles.active', 'test'
+//
+//    testLogging {
+//        events "failed" // ✅ 실패한 테스트만
+//        showStandardStreams = true // ✅ System.out.println 포함 출력
+//    }
+//}
+
 test {
     systemProperty 'spring.profiles.active', 'test'
-
-    testLogging {
-        events "failed" // ✅ 실패한 테스트만
-        showStandardStreams = true // ✅ System.out.println 포함 출력
-    }
 }

--- a/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
@@ -14,7 +14,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(properties = "spring.profiles.active=test")
+@SpringBootTest(properties = {
+    "spring.profiles.active=test",
+    "spring.data.redis.port=6379",        // ✅ 강제 설정
+    "spring.data.redis.host=localhost"    // ✅ 호스트도 같이 지정
+})
 @AutoConfigureMockMvc
 public class ApiKeyAuthFilterUnitTest {
 

--- a/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
@@ -1,14 +1,12 @@
 package org.example.honorsparkingbe.unit.util;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,7 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active=test")
 @AutoConfigureMockMvc
 public class ApiKeyAuthFilterUnitTest {
 
@@ -24,11 +22,6 @@ public class ApiKeyAuthFilterUnitTest {
   private MockMvc mockMvc;
   @Autowired
   private ObjectMapper objectMapper;
-
-  @BeforeAll
-  static void setUp() {
-    System.setProperty("api.key", "valid-api-key");
-  }
 
   @Test
   void API_KEY가_정상적으로_인증되면_200_OK() throws Exception {
@@ -44,14 +37,24 @@ public class ApiKeyAuthFilterUnitTest {
 
   @Test
   void API_KEY가_없으면_401_UNAUTHORIZED() throws Exception {
-    mockMvc.perform(get("/api/v1/sync/inout")) // ❌ API Key 없음
+    String requestBody = objectMapper.writeValueAsString(Map.of("inoutList", List.of()));
+
+    mockMvc.perform(post("/api/v1/sync/inout") // ❌ API Key 없음
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody).with(csrf())
+        )
         .andExpect(status().isUnauthorized());
   }
 
   @Test
   void API_KEY가_잘못되면_401_UNAUTHORIZED() throws Exception {
-    mockMvc.perform(get("/api/v1/sync/inout")
-            .header("X-API-KEY", "wrong-key")) // ❌ 잘못된 API Key
+    String requestBody = objectMapper.writeValueAsString(Map.of("inoutList", List.of()));
+
+    mockMvc.perform(post("/api/v1/sync/inout")
+            .header("X-API-KEY", "wrongKey") // ❌ 잘못된 API Key
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody).with(csrf())
+        )
         .andExpect(status().isUnauthorized());
   }
 }

--- a/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -15,7 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest(properties = {"api.key=valid-api-key"})
+@SpringBootTest
 @AutoConfigureMockMvc
 public class ApiKeyAuthFilterUnitTest {
 
@@ -24,10 +25,10 @@ public class ApiKeyAuthFilterUnitTest {
   @Autowired
   private ObjectMapper objectMapper;
 
-//  @DynamicPropertySource
-//  static void setProperties(DynamicPropertyRegistry registry) {
-//    registry.add("api.key", () -> "valid-api-key");
-//  }
+  @BeforeAll
+  static void setUp() {
+    System.setProperty("api.key", "valid-api-key");
+  }
 
   @Test
   void API_KEY가_정상적으로_인증되면_200_OK() throws Exception {

--- a/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/ApiKeyAuthFilterUnitTest.java
@@ -13,11 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-@SpringBootTest
+@SpringBootTest(properties = {"api.key=valid-api-key"})
 @AutoConfigureMockMvc
 public class ApiKeyAuthFilterUnitTest {
 
@@ -26,10 +24,10 @@ public class ApiKeyAuthFilterUnitTest {
   @Autowired
   private ObjectMapper objectMapper;
 
-  @DynamicPropertySource
-  static void setProperties(DynamicPropertyRegistry registry) {
-    registry.add("api.key", () -> "valid-api-key");
-  }
+//  @DynamicPropertySource
+//  static void setProperties(DynamicPropertyRegistry registry) {
+//    registry.add("api.key", () -> "valid-api-key");
+//  }
 
   @Test
   void API_KEY가_정상적으로_인증되면_200_OK() throws Exception {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,3 +35,5 @@ spring:
   h2:
     console:
       enabled: true
+api:
+  key: valid-api-key

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -26,8 +26,8 @@ spring:
     properties:
       hibernate.dialect: org.hibernate.dialect.MySQL8Dialect
       hibernate:
-        format_sql: true
-    show-sql: true
+        format_sql: false
+    show-sql: false
     generate-ddl: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
     database: h2


### PR DESCRIPTION
1. origin develop에서 지금 CI가 실패하고있습니다. 하지만 로컬에서는 문제가 안발생하네요
2. 따라서 핵심은 properties값 주입방식에서 나타날 수 있다고 판단해 주입방식을 수정했습니다