### PR TITLE
Feat/alarm session edit

### DIFF
--- a/src/main/java/org/example/honorsparkingbe/controller/AlarmController.java
+++ b/src/main/java/org/example/honorsparkingbe/controller/AlarmController.java
@@ -39,7 +39,12 @@ public class AlarmController {
             @RequestParam(defaultValue = "20") int size) {
 
         try {
-            Long memberId = getCurrentMemberId();
+            // SecurityUtil 사용하도록 변경
+            // Controller에서도 memberId == null 체크를 넣는 건 방어적 코딩 + 명확한 API 에러 처리 차원에서 추천된다고 합니다.
+            Long memberId = SecurityUtil.getCurrentUserId();
+            if (memberId == null) {
+                return ResponseEntity.status(401).body(Map.of("error", "로그인 필요"));
+            }
 
             // JPA 에서는 page 0부터 시작하므로
             int adjustedPage = Math.max(page - 1, 0); // 음수 방지
@@ -69,6 +74,11 @@ public class AlarmController {
         try{
             // Long memberId = getCurrentMemberId(); // 시현씨가 따로 구현한 걸로 OAuth2 실패(SecurityUtil 사용할 것)
             Long memberId= SecurityUtil.getCurrentUserId();
+
+            if (memberId == null) {
+                return ResponseEntity.status(401).body(Map.of("error", "로그인 필요"));
+            }
+
             boolean hasUnread= alarmService.hasUnreadAlarms(memberId);
             return ResponseEntity.ok(Map.of("hasUnread", hasUnread));
         }catch (Exception e){
@@ -125,7 +135,12 @@ public class AlarmController {
     @DeleteMapping("/alarm/all")
     public ResponseEntity<Map<String, Object>> deleteAllAlarms() {
         try {
-            Long memberId = getCurrentMemberId(); // 로그인한 사용자 ID 가져오기
+            // SecurityUtil 사용하도록 변경
+            Long memberId = SecurityUtil.getCurrentUserId();
+            if (memberId == null) {
+                return ResponseEntity.status(401).body(Map.of("error", "로그인 필요"));
+            }
+
             Map<String, Object> response = alarmService.deleteAllAlarms(memberId);
             return ResponseEntity.ok(response);
         } catch (IllegalStateException e) {  // 인증되지 않은 경우 예외 처리
@@ -135,45 +150,45 @@ public class AlarmController {
         }
     }
 
-    /**
-     * 현재 로그인한 사용자의 memberId 가져오기
-     * 일반 로그인: UserDetails에서 authId 가져와서 memberId 조회
-     * 소셜 로그인: OAuth2User에서 socialId 가져와서 memberId 조회
-     * @return memberId
-     */
-    private Long getCurrentMemberId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new IllegalStateException("User is not authenticated");
-        }
-
-        Object principal = authentication.getPrincipal();
-        System.out.println("Principal: " + principal.getClass().getName()); // 디버깅 로그
-
-        // 일반 로그인 처리 (UserDetails 기반)
-        if (principal instanceof UserDetails userDetails) {
-            return findMemberIdByAuthId(userDetails.getUsername()); // authId → memberId 조회
-        }
-
-        // 소셜 로그인 처리 (OAuth2User)
-        if (principal instanceof OAuth2User oAuth2User) {
-            String authId = (String) oAuth2User.getAttribute("sub"); // 소셜 로그인 고유 ID
-            return findMemberIdByAuthId(authId);  // 🔥 authId로 memberId 조회
-        }
-
-        throw new IllegalStateException("Invalid user authentication data");
-    }
-
-    /**
-     * 로그인 사용자의 authId로 memberId 조회
-     */
-    private Long findMemberIdByAuthId(String authId) {
-        Long memberId = alarmService.findMemberIdByAuthId(authId);
-        if (memberId == null) {
-            throw new IllegalStateException("User not found with authId: " + authId);
-        }
-        return memberId;
-    }
+//    /**
+//     * 현재 로그인한 사용자의 memberId 가져오기
+//     * 일반 로그인: UserDetails에서 authId 가져와서 memberId 조회
+//     * 소셜 로그인: OAuth2User에서 socialId 가져와서 memberId 조회
+//     * @return memberId
+//     */
+//    private Long getCurrentMemberId() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//
+//        if (authentication == null || !authentication.isAuthenticated()) {
+//            throw new IllegalStateException("User is not authenticated");
+//        }
+//
+//        Object principal = authentication.getPrincipal();
+//        System.out.println("Principal: " + principal.getClass().getName()); // 디버깅 로그
+//
+//        // 일반 로그인 처리 (UserDetails 기반)
+//        if (principal instanceof UserDetails userDetails) {
+//            return findMemberIdByAuthId(userDetails.getUsername()); // authId → memberId 조회
+//        }
+//
+//        // 소셜 로그인 처리 (OAuth2User)
+//        if (principal instanceof OAuth2User oAuth2User) {
+//            String authId = (String) oAuth2User.getAttribute("sub"); // 소셜 로그인 고유 ID
+//            return findMemberIdByAuthId(authId);  // 🔥 authId로 memberId 조회
+//        }
+//
+//        throw new IllegalStateException("Invalid user authentication data");
+//    }
+//
+//    /**
+//     * 로그인 사용자의 authId로 memberId 조회
+//     */
+//    private Long findMemberIdByAuthId(String authId) {
+//        Long memberId = alarmService.findMemberIdByAuthId(authId);
+//        if (memberId == null) {
+//            throw new IllegalStateException("User not found with authId: " + authId);
+//        }
+//        return memberId;
+//    }
 
 }

--- a/src/test/java/org/example/honorsparkingbe/unit/controller/AlarmControllerAuthTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/controller/AlarmControllerAuthTest.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.example.honorsparkingbe.controller.AlarmController;
 import org.example.honorsparkingbe.domain.entity.MemberEntity;
 import org.example.honorsparkingbe.domain.enums.MemberRole;
+import org.example.honorsparkingbe.dto.*;
 import org.example.honorsparkingbe.security.CustomUserDetails;
 import org.example.honorsparkingbe.service.AlarmService;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,10 +59,11 @@ public class AlarmControllerAuthTest {
                 .build();
 
         // SecurityContext에 사용자 인증 정보 설정
-        MemberEntity mockMember = new MemberEntity();
-        mockMember.setId(1L);
-        mockMember.setAuthId("testuser");
-        mockMember.setRole(MemberRole.ROLE_USER); // 명시적 역할 설정
+        MemberEntity mockMember = MemberEntity.builder()
+                .id(1L)
+                .authId("testuser")
+                .role(MemberRole.ROLE_USER)
+                .build();
 
         CustomUserDetails customUserDetails = new CustomUserDetails(mockMember);
         Authentication authentication = new UsernamePasswordAuthenticationToken(
@@ -73,38 +75,200 @@ public class AlarmControllerAuthTest {
     }
 
     /**
-     * 1. 알람 목록 조회 테스트 (GET /api/v1/alarmAll)
+     * 1-1. (일반 로그인) 알람 목록 조회 테스트 (GET /api/v1/alarmAll)
      */
     @Test
-    @DisplayName("알람 목록 조회 성공")
-    @WithMockUser(username = "testuser", roles = {"USER"})
+    @DisplayName("일반 로그인 사용자 - 알람 목록 조회 성공")
     void testGetAlarms_Success() throws Exception {
-
-        // Given
+        // given
         Map<String, Object> mockResponse = Map.of(
-                "pagination", Map.of("currentPage", 1),  // 0페이지가 입력되면 +1을 적용하는 로직
+                "pagination", Map.of("currentPage", 1),
                 "alarms", List.of(Map.of("id", 1L, "content", "Test Alarm"))
         );
 
         when(alarmService.getAlarms(any(Long.class), any(), any(Integer.class), any(Integer.class)))
                 .thenReturn(mockResponse);
 
-        // When & Then
+        // when & then
         mockMvc.perform(get("/api/v1/alarmAll")
                         .param("category", "info")
                         .param("page", "1")
                         .param("size", "10"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.pagination.currentPage").value(2))  // 기존 1 → 2로 수정
+                .andExpect(jsonPath("$.pagination.currentPage").value(2)) // 로직상 +1 처리
                 .andExpect(jsonPath("$.alarms[0].content").value("Test Alarm"));
     }
+//    @WithMockUser(username = "testuser", roles = {"USER"})
+//    void testGetAlarms_Success() throws Exception {
+//
+//        // Given
+//        Map<String, Object> mockResponse = Map.of(
+//                "pagination", Map.of("currentPage", 1),  // 0페이지가 입력되면 +1을 적용하는 로직
+//                "alarms", List.of(Map.of("id", 1L, "content", "Test Alarm"))
+//        );
+//
+//        when(alarmService.getAlarms(any(Long.class), any(), any(Integer.class), any(Integer.class)))
+//                .thenReturn(mockResponse);
+//
+//        // When & Then
+//        mockMvc.perform(get("/api/v1/alarmAll")
+//                        .param("category", "info")
+//                        .param("page", "1")
+//                        .param("size", "10"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.pagination.currentPage").value(2))  // 기존 1 → 2로 수정
+//                .andExpect(jsonPath("$.alarms[0].content").value("Test Alarm"));
+//    }
+
+
+    /**
+     * 1-2. (구글 로그인) 알람 목록 조회 테스트 (GET /api/v1/alarmAll)
+     */
+    @Test
+    @DisplayName("구글 로그인 사용자 - 알람 목록 조회 성공")
+    void testGetAlarms_Success_WithSocialLogin() throws Exception {
+        // 1. attributes
+        Map<String, Object> attributes = Map.of(
+                "sub", "google 12345",
+                "name", "소셜유저",
+                "email", "social@user.com"
+        );
+
+        // 2. OAuth2Response mock
+        OAuth2Response mockResponse = new GoogleResponse(attributes);
+
+        // 3. CustomOAuth2User
+        CustomOAuth2User socialUser = new CustomOAuth2User(mockResponse, "ROLE_USER", 6L);
+
+        // 4. SecurityContextHolder 설정
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                socialUser, null, socialUser.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        // 5. 서비스 mock 응답
+        Map<String, Object> mockResponseData = Map.of(
+                "pagination", Map.of("currentPage", 1),
+                "alarms", List.of(Map.of("id", 6L, "content", "Social Alarm"))
+        );
+
+        when(alarmService.getAlarms(any(Long.class), any(), any(Integer.class), any(Integer.class)))
+                .thenReturn(mockResponseData);
+
+        // 6. API 호출 및 검증
+        mockMvc.perform(get("/api/v1/alarmAll")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pagination.currentPage").value(2))
+                .andExpect(jsonPath("$.alarms[0].content").value("Social Alarm"));
+    }
+
+    /**
+     * 1-3. (카카오 로그인) 알람 목록 조회 테스트 (GET /api/v1/alarmAll)
+     */
+    @Test
+    @DisplayName("카카오 로그인 사용자 - 알람 목록 조회 성공")
+    void testGetAlarms_Success_WithKakaoLogin() throws Exception {
+        // 1. attributes (카카오 스타일)
+        Map<String, Object> attributes = Map.of(
+                "id", 98765L,
+                "kakao_account", Map.of(
+                        "email", "kakao@user.com",
+                        "profile", Map.of("nickname", "카카오유저"),
+                        "birthday", "0101",
+                        "birthyear", "1990",
+                        "phone_number", "010-1234-5678"
+                )
+        );
+
+        // 2. OAuth2Response mock - KakaoResponse
+        OAuth2Response kakaoResponse = new KakaoResponse(attributes);
+
+        // 3. CustomOAuth2User 생성
+        CustomOAuth2User kakaoUser = new CustomOAuth2User(kakaoResponse, "ROLE_USER", 7L);
+
+        // 4. SecurityContextHolder 설정
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                kakaoUser, null, kakaoUser.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        // 5. 서비스 mock 응답 설정
+        Map<String, Object> mockResponseData = Map.of(
+                "pagination", Map.of("currentPage", 0),
+                "alarms", List.of(Map.of("id", 7L, "content", "Kakao Alarm"))
+        );
+
+        when(alarmService.getAlarms(any(Long.class), any(), any(Integer.class), any(Integer.class)))
+                .thenReturn(mockResponseData);
+
+        // 6. API 호출 및 응답 검증
+        mockMvc.perform(get("/api/v1/alarmAll")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pagination.currentPage").value(1))
+                .andExpect(jsonPath("$.alarms[0].content").value("Kakao Alarm"));
+    }
+
+    /**
+     * 1-4. (네이버 로그인) 알람 목록 조회 테스트 (GET /api/v1/alarmAll)
+     */
+    @Test
+    @DisplayName("네이버 로그인 사용자 - 알람 목록 조회 성공")
+    void testGetAlarms_Success_WithNaverLogin() throws Exception {
+        // 1. attributes (네이버는 응답 데이터가 nested로 오는 구조)
+        Map<String, Object> responseData = Map.of(
+                "id", "naver_abc123",
+                "name", "네이버유저",
+                "email", "naver@user.com",
+                "mobile", "010-1234-5678",
+                "birthday", "12-31",
+                "birthyear", "1994"
+        );
+
+        Map<String, Object> attributes = Map.of("response", responseData);
+
+        // 2. NaverResponse mock
+        OAuth2Response mockResponse = new NaverResponse(attributes);
+
+        // 3. CustomOAuth2User 생성
+        CustomOAuth2User naverUser = new CustomOAuth2User(mockResponse, "ROLE_USER", 8L);
+
+        // 4. SecurityContextHolder 설정
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                naverUser, null, naverUser.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+
+        // 5. 서비스 mock 응답
+        Map<String, Object> mockResponseData = Map.of(
+                "pagination", Map.of("currentPage", 1),
+                "alarms", List.of(Map.of("id", 8L, "content", "Naver Alarm"))
+        );
+
+        when(alarmService.getAlarms(any(Long.class), any(), any(Integer.class), any(Integer.class)))
+                .thenReturn(mockResponseData);
+
+        // 6. 호출 및 검증
+        mockMvc.perform(get("/api/v1/alarmAll")
+                        .param("page", "1")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pagination.currentPage").value(2))
+                .andExpect(jsonPath("$.alarms[0].content").value("Naver Alarm"));
+    }
+
 
     /**
      * 읽지 않은 알람 존재 여부 조회 (GET /api/v1/alarmUnread)
      */
     @Test
     @DisplayName("읽지 않은 알람 존재 여부 조회")
-    @WithMockUser(username = "testuser", roles = {"USER"})
     void testGetUnreadAlarms_Success() throws Exception {
         when(alarmService.hasUnreadAlarms(any(Long.class))).thenReturn(true);
 
@@ -112,6 +276,14 @@ public class AlarmControllerAuthTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.hasUnread").value(true));
     }
+//    @WithMockUser(username = "testuser", roles = {"USER"})
+//    void testGetUnreadAlarms_Success() throws Exception {
+//        when(alarmService.hasUnreadAlarms(any(Long.class))).thenReturn(true);
+//
+//        mockMvc.perform(get("/api/v1/alarmUnread"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.hasUnread").value(true));
+//    }
 
 
 
@@ -122,7 +294,6 @@ public class AlarmControllerAuthTest {
  */
     @Test
     @DisplayName("알람 전체 삭제 성공")
-    @WithMockUser(username = "testuser", roles = {"USER"}) // 인증된 사용자 추가
     void testDeleteAllAlarms_Success() throws Exception {
         Map<String, Object> mockResponse = Map.of("success", true, "deletedCount", 10);
 
@@ -133,6 +304,17 @@ public class AlarmControllerAuthTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.deletedCount").value(10));
     }
+//    @WithMockUser(username = "testuser", roles = {"USER"}) // 인증된 사용자 추가
+//    void testDeleteAllAlarms_Success() throws Exception {
+//        Map<String, Object> mockResponse = Map.of("success", true, "deletedCount", 10);
+//
+//        when(alarmService.deleteAllAlarms(any(Long.class))).thenReturn(mockResponse);
+//
+//        mockMvc.perform(delete("/api/v1/alarm/all").with(csrf()))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.success").value(true))
+//                .andExpect(jsonPath("$.deletedCount").value(10));
+//    }
 
 
 


### PR DESCRIPTION
AlarmController 내 사용자 인증 방식을 SecurityContextHolder에서 SecurityUtil.getCurrentUserId()로 변경하여 일반 로그인 및 소셜 로그인(Google, Kakao, Naver) 사용자 모두 알람 조회가 가능하도록 리팩토링했습니다.

또한 AlarmControllerAuthTest에 소셜 로그인 사용자 테스트(Google, Kakao, Naver) 케이스를 추가했습니다.