### PR TITLE
Fix/cicd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Deploy To EC2
 on:
   push:
     branches:
-      #- feat/cicd
-      - fix/cicd
+      #      - fix/cicd
       - develop
 
 jobs:
@@ -35,16 +34,11 @@ jobs:
           mkdir -p ./src/main/resources/config
           echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/config/application.properties
 
-      # application-test.yml 파일 생성
-      #      - name: application-test.yml 파일 만들기
-      #        run: |
-      #          mkdir -p ./src/test/resources/config
-      #          echo "${{ secrets.APPLICATION_TEST_YML }}" > ./src/test/resources/config/application-test.yml
 
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build -x test
 
-      # ECR에 접근할 수 있는 권한을 허용받기 위해
+      # AWS 접근 가능 권한 받기
       - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -52,25 +46,20 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-      #      - name: ECR에 로그인하기
-      #        id: login-ecr
-      #        # 라이브러리가 있음
-      #        uses: aws-actions/amazon-ecr-login@v2
+      # 도커 로그인 및 이미지 푸쉬
 
-      - name: Docker 이미지 생성
-        run: docker compose build
-
-      - name: Docker 이미지에 Tag 붙이기
-        run: docker tag honors-parking-backend:latest ${{ secrets.DOCKERHUB_USERNAME }}/honors-parking-backend:latest
-
+      # DockerHub Login
       - name: Docker Hub Login
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker 이미지 Push하기
-        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/honors-parking-backend:latest
+      # DockerHub Push
+      - name: Docker 이미지 생성 후 푸쉬
+        run: docker buildx create --use
+      - name: buildx를 활요한 이미지 빌드 후 푸쉬
+        run: ./gradlew dockerBuildxMultiPlatform
 
       - name: SSH(원격 접속)로 EC2에 접속하기
         uses: appleboy/ssh-action@v1.0.3
@@ -80,7 +69,6 @@ jobs:
           key: ${{ secrets.EC2_PRIVATE_KEY }}
           script_stop: true
           script: |
-            docker stop honors-parking-backend || true
-            docker rm honors-parking-backend || true
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/honors-parking-backend:latest
+            docker compose down
+            docker pull gyural/honors-parking-buildx:latest
             docker compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy To EC2
 on:
   push:
     branches:
-      #      - fix/cicd
-      - develop
+      - fix/cicd
+#      - develop
 
 jobs:
   deploy:
@@ -15,35 +15,51 @@ jobs:
         # 레포지토리에 저장되어있는 코드 불러오는 라이브러리
         uses: actions/checkout@v4
 
-      # 테스트 할 때 필요한 JDK 설치
+      # Github Actions에 빌드, 테스트 할 때 필요한 JDK 설치
       - name: JDK 21 설치 (Oracle)
         uses: actions/setup-java@v4
         with:
           distribution: oracle
           java-version: 21
-
-      # application.yml파일 추가
       - name: application.yml 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          echo '${{ secrets.APPLICATION_YML }}' > ./src/main/resources/config/application.yml
-      # application.properties파일 추가
+          cat <<EOF > ./src/main/resources/config/application.yml
+          ${{ secrets.APPLICATION_YML }}
+          EOF
+
+      - name: application.yml 내용 확인 (디버그용)
+        run: |
+          echo "📂 application.yml 파일 내용:"
+          echo "----------------------------------"
+          cat ./src/main/resources/config/application.yml
+          echo "----------------------------------"
+
       - name: application.properties 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          echo '${{ secrets.APPLICATION_PROPERTIES }}' > ./src/main/resources/config/application.properties
+          cat <<EOF > ./src/main/resources/config/application.properties
+          ${{ secrets.APPLICATION_PROPERTIES }}
+          EOF
 
-      # 테스트 빌드
-      - name: 테스트 및 빌드하기
-        run: ./gradlew clean build
+      - name: application.properties 내용 확인 (디버그용)
+        run: |
+          echo "📂 application.properties 파일 내용:"
+          echo "----------------------------------"
+          cat ./src/main/resources/config/application.properties
+          echo "----------------------------------"
+      
 
-      # AWS 접근 가능 권한 받기
-      - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ap-northeast-2
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #      - name: 테스트 및 빌드하기
+      #        run: ./gradlew clean build
+      #
+      #      # AWS 접근 가능 권한 받기
+      #      - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
+      #        uses: aws-actions/configure-aws-credentials@v4
+      #        with:
+      #          aws-region: ap-northeast-2
+      #          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       # 도커 로그인 및 이미지 푸쉬
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,28 +15,27 @@ jobs:
         # 레포지토리에 저장되어있는 코드 불러오는 라이브러리
         uses: actions/checkout@v4
 
-      # Github Actions에 빌드, 테스트 할 때 필요한 JDK 설치
+      # 테스트 할 때 필요한 JDK 설치
       - name: JDK 21 설치 (Oracle)
         uses: actions/setup-java@v4
         with:
           distribution: oracle
           java-version: 21
 
-      # application.yml 파일 생성
+      # application.yml파일 추가
       - name: application.yml 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/config/application.yml
-
-      # application.properties 파일 생성
+          echo '${{ secrets.APPLICATION_YML }}' > ./src/main/resources/config/application.yml
+      # application.properties파일 추가
       - name: application.properties 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/config/application.properties
+          echo '${{ secrets.APPLICATION_PROPERTIES }}' > ./src/main/resources/config/application.properties
 
-
+      # 테스트 빌드
       - name: 테스트 및 빌드하기
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
 
       # AWS 접근 가능 권한 받기
       - name: AWS Resource에 접근할 수 있게 AWS credentials 설정

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy To EC2
 on:
   push:
     branches:
-      - fix/cicd
-#      - develop
+      #      - fix/cicd
+      - develop
 
 jobs:
   deploy:
@@ -15,54 +15,35 @@ jobs:
         # 레포지토리에 저장되어있는 코드 불러오는 라이브러리
         uses: actions/checkout@v4
 
-      # Github Actions에 빌드, 테스트 할 때 필요한 JDK 설치
+      # 테스트 할 때 필요한 JDK 설치
       - name: JDK 21 설치 (Oracle)
         uses: actions/setup-java@v4
         with:
           distribution: oracle
           java-version: 21
+
+      # application.yml파일 추가
       - name: application.yml 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
           echo '${{ secrets.APPLICATION_YML }}' > ./src/main/resources/config/application.yml
-
-      - name: application.yml 내용 확인 (디버그용)
-        run: |
-          echo "📂 application.yml 파일 내용:"
-          echo "----------------------------------"
-          cat ./src/main/resources/config/application.yml
-          echo "----------------------------------"
-
+      # application.properties파일 추가
       - name: application.properties 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
           echo '${{ secrets.APPLICATION_PROPERTIES }}' > ./src/main/resources/config/application.properties
 
-      - name: application.properties 내용 확인 (디버그용)
-        run: |
-          echo "📂 application.properties 파일 내용:"
-          echo "----------------------------------"
-          cat ./src/main/resources/config/application.properties
-          echo "----------------------------------"
+      # 테스트 빌드
+      - name: 테스트 및 빌드하기
+        run: ./gradlew clean build
 
-      # 📦 아티팩트로 업로드
-      - name: 📤 설정파일 아티팩트로 업로드
-        uses: actions/upload-artifact@v4
+      # AWS 접근 가능 권한 받기
+      - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: application-config-files
-          path: ./src/main/resources/config/
-      
-
-      #      - name: 테스트 및 빌드하기
-      #        run: ./gradlew clean build
-      #
-      #      # AWS 접근 가능 권한 받기
-      #      - name: AWS Resource에 접근할 수 있게 AWS credentials 설정
-      #        uses: aws-actions/configure-aws-credentials@v4
-      #        with:
-      #          aws-region: ap-northeast-2
-      #          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       # 도커 로그인 및 이미지 푸쉬
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,7 @@ jobs:
       - name: application.yml 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          cat <<EOF > ./src/main/resources/config/application.yml
-          ${{ secrets.APPLICATION_YML }}
-          EOF
+          echo '${{ secrets.APPLICATION_YML }}' > ./src/main/resources/config/application.yml
 
       - name: application.yml 내용 확인 (디버그용)
         run: |
@@ -38,9 +36,7 @@ jobs:
       - name: application.properties 파일 만들기
         run: |
           mkdir -p ./src/main/resources/config
-          cat <<EOF > ./src/main/resources/config/application.properties
-          ${{ secrets.APPLICATION_PROPERTIES }}
-          EOF
+          echo '${{ secrets.APPLICATION_PROPERTIES }}' > ./src/main/resources/config/application.properties
 
       - name: application.properties 내용 확인 (디버그용)
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,13 @@ jobs:
           echo "----------------------------------"
           cat ./src/main/resources/config/application.properties
           echo "----------------------------------"
+
+      # 📦 아티팩트로 업로드
+      - name: 📤 설정파일 아티팩트로 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: application-config-files
+          path: ./src/main/resources/config/
       
 
       #      - name: 테스트 및 빌드하기

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
         uses: actions/checkout@v4
 
       # Github Actions에 빌드, 테스트 할 때 필요한 JDK 설치
-      - name: JDK 21 설치
+      - name: JDK 21 설치 (Oracle)
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: oracle
           java-version: 21
 
       # application.yml 파일 생성

--- a/build.gradle
+++ b/build.gradle
@@ -97,3 +97,22 @@ test {
         showStackTraces true
     }
 }
+
+tasks.register("dockerBuildxMultiPlatform", Exec) {
+    dependsOn bootJar
+
+    group = "docker"
+    description = "Build and push multi-platform docker image using buildx"
+
+    def imageName = "gyural/honors-parking-buildx:latest"
+
+    commandLine "docker", "buildx", "build",
+            "--platform", "linux/amd64,linux/arm64",
+            "-t", imageName,
+            "--push",
+            "."
+
+    doFirst {
+        println "Building multi-platform Docker image: ${imageName}"
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     restart: always
     ports:
       - "6379:6379"
+    networks:
+      - my-network
   db:
     image: mysql
     platform: linux/amd64
@@ -21,24 +23,33 @@ services:
       - "3306:3306"
     volumes:
       - mysql-data:/var/lib/mysql
+    networks:
+      - my-network
 
   backend:
     container_name: honorsParking
     depends_on:
       - db
       - redis
-    platform: linux/amd64
-    #    platform: linux/arm64
-    build: .
+    image: gyural/honors-parking-buildx:latest
+    #    platform: linux/amd64
+    platform: linux/arm64
+
     ports:
       - "8080:8080"
     environment:
-      db-url: jdbc:mysql://db:3306/parking
-      db-username: user
-      db-password: 1234
-      redis-host: redis
-      redis-port: 6379
+      DB_URL: jdbc:mysql://db:3306/parking
+      DB_USERNAME: user
+      DB_PASSWORD: 1234
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       SPRING_PROFILES_ACTIVE: performanceTest
+    networks:
+      - my-network
 
 volumes:
   mysql-data:
+
+networks:
+  my-network:
+    driver: bridge


### PR DESCRIPTION
# 1. CICD 스크립트 오류 수정
기존에 EC2상에서 DB커넥션을 실패하는 이유를 발견하고 해결해줬습니다..!!

그 이유는 현재 application.file들이
```url : ${db-url:localhost:3306/test/}```
이런식으로 되어있는데

저희 로컬에서는 환경변수를 가져올 곳이 한군데 밖에 없자나여???
근데 깃 액션은 Secrets에서 환경변수를 가져와야합니다..!!
따라서 있지도않은 ${db-url}값을 텍스트로 인식하지 않고 보간값으로 인식하는 문제 가 발생해서 이를 해결해 줬습니다.

방법은 쉬웠습니다.
### Before
```echo ${{ secrets.APPLICATION_YML }} > ./src/main/resources/config/application.yml```

### After
```echo '${{ secrets.APPLICATION_YML }}' > ./src/main/resources/config/application.yml```
네  따옴표를 넣으면 텍스트로 인식합니다... ${}문자를요 ㅎㅎㅎ...

# 2. CICD 명령어 간소화

기존에 모든 컨테이너를 하나하나 종료하고 시작했는데
그냥 docker-compose file을 만들어놓고 사전에
compsoe down -> 최신 이미지 Pull -> compose Up 하게 간소화 했습니다.