### PR TITLE
Feat/kaako local api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     //For log
@@ -77,7 +79,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.4.0'
 
     implementation 'commons-net:commons-net:3.9.0' // FTP 클라이언트
-
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/honorsparkingbe/controller/SearchLocalController.java
+++ b/src/main/java/org/example/honorsparkingbe/controller/SearchLocalController.java
@@ -1,0 +1,36 @@
+package org.example.honorsparkingbe.controller;
+
+import static org.example.honorsparkingbe.security.util.SecurityUtil.getCurrentUserId;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.request.SearchLocalRequest;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
+import org.example.honorsparkingbe.service.SearchLocalService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/search/local")
+@RequiredArgsConstructor
+public class SearchLocalController {
+
+  private final SearchLocalService searchLocalService;
+
+  @GetMapping
+  ResponseEntity<SearchLocalResponse> searchLocal(
+      @ModelAttribute @Valid SearchLocalRequest request) {
+
+    return ResponseEntity.ok(searchLocalService.getLocalInfoByKeyword(SearchLocalDTO.builder()
+        .keyword(request.getKeyword())
+        .memberId(getCurrentUserId())
+        .page(request.getPage())
+        .longitudeX(request.getLongitudeX())
+        .latitudeY(request.getLatitudeY())
+        .build()));
+  }
+}

--- a/src/main/java/org/example/honorsparkingbe/dto/KakaoLocalAPIDTO.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/KakaoLocalAPIDTO.java
@@ -1,0 +1,17 @@
+//package org.example.honorsparkingbe.dto;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//@Data
+//@Builder
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class KakaoLocalAPIDTO {
+//
+//  private Meta meta;
+//  List<document> documents;
+//
+//}

--- a/src/main/java/org/example/honorsparkingbe/dto/SearchLocalDTO.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/SearchLocalDTO.java
@@ -1,0 +1,15 @@
+package org.example.honorsparkingbe.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SearchLocalDTO {
+
+  private Long memberId;
+  private String keyword;
+  private Double longitudeX;
+  private Double latitudeY;
+  private Integer page;
+}

--- a/src/main/java/org/example/honorsparkingbe/dto/request/SearchLocalRequest.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/request/SearchLocalRequest.java
@@ -1,0 +1,25 @@
+package org.example.honorsparkingbe.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SearchLocalRequest {
+
+  @NotNull(message = "keyword 쿼리 파라매터는 필수입니다.")
+  private String keyword;
+  private Double longitudeX;
+  private Double latitudeY;
+  @Min(value = 0, message = "page는 0 이상이어야 합니다.")
+  private Integer page;
+
+  @AssertTrue(message = "latitude와 longitude는 둘 다 존재하거나 둘 다 없어야 합니다.")
+  public boolean isCoordinateValid() {
+    return (longitudeX == null && latitudeY == null) ||
+        (longitudeX != null && latitudeY != null);
+  }
+}

--- a/src/main/java/org/example/honorsparkingbe/dto/response/KakaoLocalClientResponse.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/response/KakaoLocalClientResponse.java
@@ -1,0 +1,90 @@
+package org.example.honorsparkingbe.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class KakaoLocalClientResponse {
+
+  @JsonProperty("meta")
+  private Meta meta;
+
+  @JsonProperty("documents")
+  private List<Document> documents;
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Meta {
+
+    @JsonProperty("same_name")
+    private SameName sameName;
+
+    @JsonProperty("pageable_count")
+    private int pageableCount;
+
+    @JsonProperty("total_count")
+    private int totalCount;
+
+    @JsonProperty("is_end")
+    private boolean isEnd;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class SameName {
+
+    private List<String> region;
+
+    private String keyword;
+
+    @JsonProperty("selected_region")
+    private String selectedRegion;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Document {
+
+    @JsonProperty("place_name")
+    private String placeName;
+
+    private String distance;
+
+    @JsonProperty("place_url")
+    private String placeUrl;
+
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("road_address_name")
+    private String roadAddressName;
+
+    private String id;
+    private String phone;
+
+    @JsonProperty("category_group_code")
+    private String categoryGroupCode;
+
+    @JsonProperty("category_group_name")
+    private String categoryGroupName;
+
+    private String x;
+    private String y;
+  }
+}

--- a/src/main/java/org/example/honorsparkingbe/dto/response/PaginationResponse.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/response/PaginationResponse.java
@@ -2,9 +2,9 @@ package org.example.honorsparkingbe.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 
-@Getter
+@Data
 @AllArgsConstructor
 @Builder
 public class PaginationResponse {

--- a/src/main/java/org/example/honorsparkingbe/dto/response/SearchLocalResponse.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/response/SearchLocalResponse.java
@@ -1,0 +1,10 @@
+package org.example.honorsparkingbe.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SearchLocalResponse {
+
+}

--- a/src/main/java/org/example/honorsparkingbe/dto/response/SearchLocalResponse.java
+++ b/src/main/java/org/example/honorsparkingbe/dto/response/SearchLocalResponse.java
@@ -1,10 +1,43 @@
 package org.example.honorsparkingbe.dto.response;
 
+import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SearchLocalResponse {
 
+  private Meta meta;
+  private List<KakaoLocalDocument> documents;
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Meta {
+
+    private String keyword;
+    private Boolean isEnd;
+    private PaginationResponse pagination;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class KakaoLocalDocument {
+
+    private String placeName;
+    private String distance;
+    private String categoryName;
+    private String addressName;
+    private String roadAddressName;
+    private double y;
+    private double x;
+  }
 }

--- a/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
+++ b/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
@@ -1,0 +1,14 @@
+package org.example.honorsparkingbe.service;
+
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchLocalService {
+
+  public SearchLocalResponse getLocalInfoByKeyword(SearchLocalDTO dto) {
+
+    return SearchLocalResponse.builder().build();
+  }
+}

--- a/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
+++ b/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
@@ -1,14 +1,21 @@
 package org.example.honorsparkingbe.service;
 
+import lombok.RequiredArgsConstructor;
 import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse;
 import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
+import org.example.honorsparkingbe.util.client.KakaoLocalSearchClient;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class SearchLocalService {
+
+  private final KakaoLocalSearchClient kakaoLocalSearchClient;
 
   public SearchLocalResponse getLocalInfoByKeyword(SearchLocalDTO dto) {
 
+    KakaoLocalClientResponse res = kakaoLocalSearchClient.getLoocalsByKeyword(dto);
     return SearchLocalResponse.builder().build();
   }
 }

--- a/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
+++ b/src/main/java/org/example/honorsparkingbe/service/SearchLocalService.java
@@ -1,9 +1,12 @@
 package org.example.honorsparkingbe.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.honorsparkingbe.dto.SearchLocalDTO;
 import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse;
+import org.example.honorsparkingbe.dto.response.PaginationResponse;
 import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse.KakaoLocalDocument;
 import org.example.honorsparkingbe.util.client.KakaoLocalSearchClient;
 import org.springframework.stereotype.Service;
 
@@ -11,11 +14,42 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SearchLocalService {
 
+  static int PAGESIZE = 10;
   private final KakaoLocalSearchClient kakaoLocalSearchClient;
 
   public SearchLocalResponse getLocalInfoByKeyword(SearchLocalDTO dto) {
 
     KakaoLocalClientResponse res = kakaoLocalSearchClient.getLoocalsByKeyword(dto);
-    return SearchLocalResponse.builder().build();
+
+    // 1. get Meta
+    SearchLocalResponse.Meta meta = SearchLocalResponse.Meta.builder()
+        .keyword(res.getMeta().getSameName().getKeyword())
+        .isEnd(res.getMeta().isEnd())
+        .pagination(PaginationResponse.builder()
+            .currentPage(dto.getPage() != null ? dto.getPage() : 0)
+            .totalPages(res.getMeta().getPageableCount() == 0 ? 0
+                : res.getMeta().getTotalCount() / PAGESIZE + 1)
+            .pageSize(PAGESIZE)
+            .totalItems(res.getMeta().getTotalCount())
+            .build())
+        .build();
+
+    // 2. get Documents
+    List<KakaoLocalDocument> documents = res.getDocuments().stream().map(
+        document -> KakaoLocalDocument.builder()
+            .placeName(document.getPlaceName())
+            .distance(document.getDistance())
+            .categoryName(document.getCategoryName())
+            .addressName(document.getAddressName())
+            .roadAddressName(document.getRoadAddressName())
+            .y(Double.parseDouble(document.getY()))
+            .x(Double.parseDouble(document.getX()))
+            .build()
+    ).toList();
+
+    return SearchLocalResponse.builder()
+        .meta(meta)
+        .documents(documents)
+        .build();
   }
 }

--- a/src/main/java/org/example/honorsparkingbe/util/client/KakaoLocalSearchClient.java
+++ b/src/main/java/org/example/honorsparkingbe/util/client/KakaoLocalSearchClient.java
@@ -31,8 +31,8 @@ public class KakaoLocalSearchClient {
         .build();
   }
 
-  static String SEARCH_PATH = "search/keyword";
-  static String AuthorizationHeader = "AuthorizationHeader";
+  static String SEARCH_PATH = "/local/search/keyword";
+  static String AuthorizationHeader = "Authorization";
   private final Logger logger = LoggerFactory.getLogger(FavoriteParkingZoneService.class);
 
   /**
@@ -43,8 +43,10 @@ public class KakaoLocalSearchClient {
   public KakaoLocalClientResponse getLoocalsByKeyword(SearchLocalDTO dto) {
     URI uri = UriComponentsBuilder.fromUriString(baseUrl)
         .path(SEARCH_PATH)
+        .queryParam("size", "10")
         .queryParam("query", dto.getKeyword())
         .build(false) // 아직 encode 하지 않음
+        .encode()
         .toUri();
 
     UriComponentsBuilder builder = UriComponentsBuilder.fromUri(uri);
@@ -58,7 +60,7 @@ public class KakaoLocalSearchClient {
       builder.queryParam("page", dto.getPage() + 1); // Kakao API는 1-based
     }
 
-    URI finalUri = builder.build(true).toUri(); // 마지막에 encode 처리
+    URI finalUri = builder.build(true).encode().toUri(); // 마지막에 encode 처리
 
     logger.info("Kakao Local Search URI: {}", finalUri);
 

--- a/src/main/java/org/example/honorsparkingbe/util/client/KakaoLocalSearchClient.java
+++ b/src/main/java/org/example/honorsparkingbe/util/client/KakaoLocalSearchClient.java
@@ -1,0 +1,81 @@
+package org.example.honorsparkingbe.util.client;
+
+import java.net.URI;
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse;
+import org.example.honorsparkingbe.service.FavoriteParkingZoneService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+@Component
+public class KakaoLocalSearchClient {
+
+  private final String baseUrl;
+  private final String authorizationKey;
+  private final WebClient webClient;
+
+  public KakaoLocalSearchClient(
+      @Value("${kakao.api.key}") String kakaoApiKey,
+      @Value("${kakao.api.base-url}") String baseUrl
+  ) {
+    this.baseUrl = baseUrl;
+    this.authorizationKey = "KakaoAK " + kakaoApiKey;
+    this.webClient = WebClient.builder()
+        .baseUrl(baseUrl)
+        .defaultHeader("Authorization", this.authorizationKey)
+        .build();
+  }
+
+  static String SEARCH_PATH = "search/keyword";
+  static String AuthorizationHeader = "AuthorizationHeader";
+  private final Logger logger = LoggerFactory.getLogger(FavoriteParkingZoneService.class);
+
+  /**
+   * 카카오 페이징은 1 베이스 넘버링이기 때문에 1이상을 줘야함
+   *
+   * @return
+   */
+  public KakaoLocalClientResponse getLoocalsByKeyword(SearchLocalDTO dto) {
+    URI uri = UriComponentsBuilder.fromUriString(baseUrl)
+        .path(SEARCH_PATH)
+        .queryParam("query", dto.getKeyword())
+        .build(false) // 아직 encode 하지 않음
+        .toUri();
+
+    UriComponentsBuilder builder = UriComponentsBuilder.fromUri(uri);
+
+    if (dto.getLongitudeX() != null && dto.getLatitudeY() != null) {
+      builder.queryParam("x", dto.getLongitudeX());
+      builder.queryParam("y", dto.getLatitudeY());
+    }
+
+    if (dto.getPage() != null) {
+      builder.queryParam("page", dto.getPage() + 1); // Kakao API는 1-based
+    }
+
+    URI finalUri = builder.build(true).toUri(); // 마지막에 encode 처리
+
+    logger.info("Kakao Local Search URI: {}", finalUri);
+
+    return webClient.get()
+        .uri(uriBuilder -> finalUri) // 직접 만든 URI를 사용
+        .header(AuthorizationHeader, authorizationKey)
+        .retrieve()
+        .onStatus(
+            status -> status.is4xxClientError() || status.is5xxServerError(),
+            clientResponse -> clientResponse
+                .bodyToMono(String.class)
+                .flatMap(errorBody -> {
+                  logger.error("Kakao API Error: {}", errorBody);
+                  return Mono.error(new RuntimeException("Kakao API 호출 실패: " + errorBody));
+                })
+        )
+        .bodyToMono(KakaoLocalClientResponse.class)
+        .block(); // 동기 처리
+  }
+}

--- a/src/test/java/org/example/honorsparkingbe/unit/controller/SearchLocalControllerTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/controller/SearchLocalControllerTest.java
@@ -1,0 +1,166 @@
+package org.example.honorsparkingbe.unit.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.apache.catalina.security.SecurityConfig;
+import org.example.honorsparkingbe.Slf4jRestControllerAdvice;
+import org.example.honorsparkingbe.controller.SearchLocalController;
+import org.example.honorsparkingbe.domain.entity.MemberEntity;
+import org.example.honorsparkingbe.domain.enums.MemberRole;
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.security.CustomUserDetails;
+import org.example.honorsparkingbe.service.SearchLocalService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@WebMvcTest
+@ContextConfiguration(classes = SecurityConfig.class)
+public class SearchLocalControllerTest {
+
+  @InjectMocks
+  SearchLocalController searchLocalController;
+  @Mock
+  SearchLocalService searchLocalService;
+  @Mock
+  private MemberEntity memberEntity;
+
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setup() {
+    memberEntity = MemberEntity.builder()
+        .password("password")
+        .role(MemberRole.ROLE_USER)
+        .userName("testUserName")
+        .id(100L)
+        .build();
+    // CustomUserDetails 생성
+    CustomUserDetails customUserDetails = new CustomUserDetails(memberEntity);
+
+    // SecurityContext에 설정
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(new UsernamePasswordAuthenticationToken(customUserDetails, null,
+        customUserDetails.getAuthorities()));
+    SecurityContextHolder.setContext(context);
+
+    // mockMvc설정
+    mockMvc = MockMvcBuilders
+        .standaloneSetup(searchLocalController)
+        .setControllerAdvice(new Slf4jRestControllerAdvice()) // 예외 핸들러 등록
+        .setCustomArgumentResolvers() // 필요하면 여기에 추가
+        .build();
+  }
+
+  @Test
+  @DisplayName("올바른 요청값 케이스들이 왔을 때 정상 작동하는지 확인")
+  void getLoaclDataByKeowrdByRightRequest() throws Exception {
+    //Given
+    String keyword = "cgv";
+    Double longitudeX = 126.9780;
+    Double latitudeY = 37.5665;
+    MultiValueMap<String, String> onlyKeywordParams = new LinkedMultiValueMap<>();
+    onlyKeywordParams.add("keyword", keyword);
+
+    MultiValueMap<String, String> keywordAndPointsParams = new LinkedMultiValueMap<>();
+    keywordAndPointsParams.add("keyword", keyword);
+    keywordAndPointsParams.add("longitudeX", longitudeX.toString());
+    keywordAndPointsParams.add("latitudeY", latitudeY.toString());
+
+    MultiValueMap<String, String> KeywordAndPointsAndPageParams = new LinkedMultiValueMap<>();
+    KeywordAndPointsAndPageParams.add("keyword", keyword);
+    KeywordAndPointsAndPageParams.add("longitudeX", longitudeX.toString());
+    KeywordAndPointsAndPageParams.add("latitudeY", latitudeY.toString());
+    KeywordAndPointsAndPageParams.add("page", "2");
+
+    SearchLocalDTO expectedDTO1 = SearchLocalDTO.builder()
+        .memberId(100L).keyword(keyword)
+        .build();
+    SearchLocalDTO expectedDTO2 = SearchLocalDTO.builder()
+        .memberId(100L).keyword(keyword).longitudeX(longitudeX).latitudeY(latitudeY)
+        .build();
+    SearchLocalDTO expectedDTO3 = SearchLocalDTO.builder()
+        .memberId(100L).keyword(keyword).longitudeX(longitudeX).latitudeY(latitudeY).page(2)
+        .build();
+    // when & then
+    mockMvc.perform(get("/api/v1/search/local").params(onlyKeywordParams))
+        .andExpect(status().isOk());
+    mockMvc.perform(get("/api/v1/search/local").params(keywordAndPointsParams))
+        .andExpect(status().isOk());
+    mockMvc.perform(get("/api/v1/search/local").params(KeywordAndPointsAndPageParams))
+        .andExpect(status().isOk());
+
+    verify(searchLocalService, times(1))
+        .getLocalInfoByKeyword(eq(expectedDTO1));
+    verify(searchLocalService, times(1))
+        .getLocalInfoByKeyword(eq(expectedDTO2));
+    verify(searchLocalService, times(1))
+        .getLocalInfoByKeyword(eq(expectedDTO3));
+
+  }
+
+  @Test
+  @DisplayName("필수 값들이 없는 케이스들이 왔을 때 에러처리가 잘 작동안하는지 확인")
+  void getLoaclDataByKeowrdByNonRightRequest() throws Exception {
+    // Given
+    String keyword = "cgv";
+    Double longitudeX = 126.9780;
+    Double latitudeY = 37.5665;
+
+    MultiValueMap<String, String> NoneKeywordParams = new LinkedMultiValueMap<>();
+    String NonKeywordErrMsg = "keyword 쿼리 파라매터는 필수입니다.";
+
+    MultiValueMap<String, String> NoneLatitudeParams = new LinkedMultiValueMap<>();
+    NoneLatitudeParams.add("keyword", keyword);
+    NoneLatitudeParams.add("longitudeX", longitudeX.toString());
+    String NoneLatitudeErrMsg = "latitude와 longitude는 둘 다 존재하거나 둘 다 없어야 합니다.";
+
+    MultiValueMap<String, String> NoneLongitudeParams = new LinkedMultiValueMap<>();
+    NoneLongitudeParams.add("keyword", keyword);
+    NoneLongitudeParams.add("latitudeY", latitudeY.toString());
+    String NoneLongitudeErrMsg = "latitude와 longitude는 둘 다 존재하거나 둘 다 없어야 합니다.";
+
+    MultiValueMap<String, String> MinusPageParams = new LinkedMultiValueMap<>();
+    MinusPageParams.add("keyword", keyword);
+    MinusPageParams.add("page", "-111");
+    String MinusPageErrMsg = "page는 0 이상이어야 합니다.";
+
+    mockMvc.perform(get("/api/v1/search/local").params(NoneKeywordParams))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value(NonKeywordErrMsg));
+
+    mockMvc.perform(get("/api/v1/search/local").params(NoneLatitudeParams))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value(NoneLatitudeErrMsg));
+
+    mockMvc.perform(get("/api/v1/search/local").params(NoneLongitudeParams))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value(NoneLongitudeErrMsg));
+
+    mockMvc.perform(get("/api/v1/search/local").params(MinusPageParams))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.message").value(MinusPageErrMsg));
+
+  }
+
+}

--- a/src/test/java/org/example/honorsparkingbe/unit/service/SearchLoaclServiceTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/service/SearchLoaclServiceTest.java
@@ -1,9 +1,16 @@
 package org.example.honorsparkingbe.unit.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse.Document;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse.SameName;
 import org.example.honorsparkingbe.dto.response.PaginationResponse;
 import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
 import org.example.honorsparkingbe.dto.response.SearchLocalResponse.KakaoLocalDocument;
@@ -33,20 +40,57 @@ public class SearchLoaclServiceTest {
     String targetKeyword = "cgv";
     SearchLocalDTO dtoWithPage0 = SearchLocalDTO.builder()
         .keyword(targetKeyword)
-        .latitudeY(36.5)
-        .longitudeX(127.0)
         .memberId(1L)
-        .page(0)
-        .build();
-    SearchLocalDTO dtoWithPage1 = SearchLocalDTO.builder()
-        .keyword(targetKeyword)
-        .latitudeY(36.5)
-        .longitudeX(127.0)
-        .memberId(1L)
-        .page(0)
         .build();
 
-    SearchLocalResponse mockKakaoLocalAPIRes = SearchLocalResponse.builder()
+    KakaoLocalClientResponse mockClientRes = KakaoLocalClientResponse.builder()
+        .meta(
+            KakaoLocalClientResponse.Meta.builder()
+                .sameName(SameName.builder()
+                    .region(List.of()).keyword(targetKeyword).selectedRegion("").build())
+                .pageableCount(2)
+                .totalCount(2)
+                .isEnd(true)
+                .build()
+        )
+        .documents(
+            List.of(
+                Document.builder()
+                    .placeName("cgv 강남점")
+                    .distance("123")
+                    .placeUrl("")
+                    .categoryName("test category")
+                    .addressName("서울시 강남동")
+                    .roadAddressName("강남로 12")
+                    .id("123123")
+                    .phone("")
+                    .categoryGroupName("test category group")
+                    .categoryGroupCode("123")
+                    .x("111.111")
+                    .y("11.11")
+                    .build()
+                ,
+                Document.builder()
+                    .placeName("cgv 논현")
+                    .distance("234")
+                    .placeUrl("")
+                    .categoryName("test category")
+                    .addressName("서울시 논현동")
+                    .roadAddressName("논현로 12")
+                    .id("321321")
+                    .phone("")
+                    .categoryGroupName("test category group")
+                    .categoryGroupCode("321")
+                    .x("222.222")
+                    .y("22.22")
+                    .build()
+            )
+        )
+        .build();
+
+    when(kakaoLocalSearchClient.getLoocalsByKeyword(dtoWithPage0)).thenReturn(mockClientRes);
+
+    SearchLocalResponse expectLocalAPIRes = SearchLocalResponse.builder()
         .meta(Meta.builder().isEnd(true).keyword(targetKeyword)
             .pagination(PaginationResponse.builder()
                 .totalItems(2)
@@ -57,22 +101,22 @@ public class SearchLoaclServiceTest {
             .build())
         .documents(List.of(
             KakaoLocalDocument.builder()
-                .placeName("cgv 용산점")
-                .distance("123")
-                .categoryName("test category")
-                .addressName("test address")
-                .roadAddressName("test road address")
-                .y(35.5)
-                .x(127.3)
+                .placeName(mockClientRes.getDocuments().get(0).getPlaceName())
+                .distance(mockClientRes.getDocuments().get(0).getDistance())
+                .categoryName(mockClientRes.getDocuments().get(0).getCategoryName())
+                .addressName(mockClientRes.getDocuments().get(0).getAddressName())
+                .roadAddressName(mockClientRes.getDocuments().get(0).getRoadAddressName())
+                .y(Double.parseDouble(mockClientRes.getDocuments().get(0).getY()))
+                .x(Double.parseDouble(mockClientRes.getDocuments().get(0).getX()))
                 .build(),
             KakaoLocalDocument.builder()
-                .placeName("cgv 이태원점")
-                .distance("123")
-                .categoryName("test category")
-                .addressName("test address")
-                .roadAddressName("test road address")
-                .y(35.5)
-                .x(127.3)
+                .placeName(mockClientRes.getDocuments().get(1).getPlaceName())
+                .distance(mockClientRes.getDocuments().get(1).getDistance())
+                .categoryName(mockClientRes.getDocuments().get(1).getCategoryName())
+                .addressName(mockClientRes.getDocuments().get(1).getAddressName())
+                .roadAddressName(mockClientRes.getDocuments().get(1).getRoadAddressName())
+                .y(Double.parseDouble(mockClientRes.getDocuments().get(1).getY()))
+                .x(Double.parseDouble(mockClientRes.getDocuments().get(1).getX()))
                 .build()))
         .build();
 
@@ -80,31 +124,193 @@ public class SearchLoaclServiceTest {
     SearchLocalResponse resPage = searchLocalService.getLocalInfoByKeyword(dtoWithPage0);
 
     // Then
-    assertEquals(targetKeyword, resPage.getMeta().getKeyword());
-    assertEquals(true, resPage.getMeta().getIsEnd());
-    assertEquals(10, resPage.getMeta().getPagination().getPageSize());
-    assertEquals(0, resPage.getMeta().getPagination().getCurrentPage());
-    assertEquals(1, resPage.getMeta().getPagination().getTotalPages());
-    assertEquals(2, resPage.getMeta().getPagination().getTotalItems());
-    assertEquals(2, resPage.getDocuments().size());
-    assertEquals(resPage.getDocuments().get(0), mockKakaoLocalAPIRes.getDocuments().get(0));
-    assertEquals(resPage.getDocuments().get(1), mockKakaoLocalAPIRes.getDocuments().get(1));
+    assertEquals(expectLocalAPIRes, resPage);
+
+    verify(kakaoLocalSearchClient, times(1))
+        .getLoocalsByKeyword(dtoWithPage0);
   }
 
   @Test
   @DisplayName("키워드와 일치하는 로컬 데이터가 있을 때 page 1 요청 확인")
   void keywordMatchedSuccessTestWithPage1() {
+    // Given
+    String targetKeyword = "cgv";
+    Double targetX = 127.0;
+    Double targetY = 36.5;
+    SearchLocalDTO dtoWithPage0 = SearchLocalDTO.builder()
+        .keyword(targetKeyword)
+        .latitudeY(targetY)
+        .longitudeX(targetX)
+        .memberId(1L)
+        .page(1)
+        .build();
+
+    KakaoLocalClientResponse mockClientRes = KakaoLocalClientResponse.builder()
+        .meta(
+            KakaoLocalClientResponse.Meta.builder()
+                .sameName(SameName.builder()
+                    .region(List.of()).keyword(targetKeyword).selectedRegion("").build())
+                .pageableCount(12)
+                .totalCount(12)
+                .isEnd(true)
+                .build()
+        )
+        .documents(
+            List.of(
+                Document.builder()
+                    .placeName("cgv 강남점")
+                    .distance("123")
+                    .placeUrl("")
+                    .categoryName("test category")
+                    .addressName("서울시 강남동")
+                    .roadAddressName("강남로 12")
+                    .id("123123")
+                    .phone("")
+                    .categoryGroupName("test category group")
+                    .categoryGroupCode("123")
+                    .x("111.111")
+                    .y("11.11")
+                    .build()
+                ,
+                Document.builder()
+                    .placeName("cgv 논현")
+                    .distance("234")
+                    .placeUrl("")
+                    .categoryName("test category")
+                    .addressName("서울시 논현동")
+                    .roadAddressName("논현로 12")
+                    .id("321321")
+                    .phone("")
+                    .categoryGroupName("test category group")
+                    .categoryGroupCode("321")
+                    .x("222.222")
+                    .y("22.22")
+                    .build()
+            )
+        )
+        .build();
+
+    when(kakaoLocalSearchClient.getLoocalsByKeyword(dtoWithPage0)).thenReturn(mockClientRes);
+
+    SearchLocalResponse expectLocalAPIRes = SearchLocalResponse.builder()
+        .meta(Meta.builder().isEnd(true).keyword(targetKeyword)
+            .pagination(PaginationResponse.builder()
+                .totalItems(12)
+                .pageSize(10)
+                .totalPages(2)
+                .currentPage(1)
+                .build())
+            .build())
+        .documents(List.of(
+            KakaoLocalDocument.builder()
+                .placeName(mockClientRes.getDocuments().get(0).getPlaceName())
+                .distance(mockClientRes.getDocuments().get(0).getDistance())
+                .categoryName(mockClientRes.getDocuments().get(0).getCategoryName())
+                .addressName(mockClientRes.getDocuments().get(0).getAddressName())
+                .roadAddressName(mockClientRes.getDocuments().get(0).getRoadAddressName())
+                .y(Double.parseDouble(mockClientRes.getDocuments().get(0).getY()))
+                .x(Double.parseDouble(mockClientRes.getDocuments().get(0).getX()))
+                .build(),
+            KakaoLocalDocument.builder()
+                .placeName(mockClientRes.getDocuments().get(1).getPlaceName())
+                .distance(mockClientRes.getDocuments().get(1).getDistance())
+                .categoryName(mockClientRes.getDocuments().get(1).getCategoryName())
+                .addressName(mockClientRes.getDocuments().get(1).getAddressName())
+                .roadAddressName(mockClientRes.getDocuments().get(1).getRoadAddressName())
+                .y(Double.parseDouble(mockClientRes.getDocuments().get(1).getY()))
+                .x(Double.parseDouble(mockClientRes.getDocuments().get(1).getX()))
+                .build()))
+        .build();
+
+    // When
+    SearchLocalResponse resPage = searchLocalService.getLocalInfoByKeyword(dtoWithPage0);
+
+    // Then
+    assertEquals(expectLocalAPIRes, resPage);
+
+    verify(kakaoLocalSearchClient, times(1))
+        .getLoocalsByKeyword(dtoWithPage0);
   }
 
   @Test
   @DisplayName("키워드와 일치하는 로컬 데이터가 없을 때 확인")
   void keywordMatchedFailTest() {
+    // Given
+    String targetKeyword = "cgv";
+    Double targetX = 127.0;
+    Double targetY = 36.5;
+    SearchLocalDTO dto = SearchLocalDTO.builder()
+        .keyword(targetKeyword)
+        .latitudeY(targetY)
+        .longitudeX(targetX)
+        .memberId(1L)
+        .page(0)
+        .build();
 
+    KakaoLocalClientResponse mockClientRes = KakaoLocalClientResponse.builder()
+        .meta(
+            KakaoLocalClientResponse.Meta.builder()
+                .sameName(SameName.builder()
+                    .region(List.of()).keyword(targetKeyword).selectedRegion("").build())
+                .pageableCount(0)
+                .totalCount(0)
+                .isEnd(true)
+                .build()
+        )
+        .documents(List.of())
+        .build();
+
+    when(kakaoLocalSearchClient.getLoocalsByKeyword(dto)).thenReturn(mockClientRes);
+
+    SearchLocalResponse expectLocalAPIRes = SearchLocalResponse.builder()
+        .meta(Meta.builder().isEnd(true).keyword(targetKeyword)
+            .pagination(PaginationResponse.builder()
+                .totalItems(0)
+                .pageSize(10)
+                .totalPages(0)
+                .currentPage(0)
+                .build())
+            .build())
+        .documents(List.of())
+        .build();
+
+    // When
+    SearchLocalResponse resPage = searchLocalService.getLocalInfoByKeyword(dto);
+
+    // Then
+    assertEquals(expectLocalAPIRes, resPage);
+
+    verify(kakaoLocalSearchClient, times(1))
+        .getLoocalsByKeyword(dto);
   }
 
   @Test
   @DisplayName("카카오 클라이언트에서 에러가 났을 때 예외처리 확인")
   void whenKakaoClientFailTest() {
 
+    // Given
+    String targetKeyword = "cgv";
+    Double targetX = 127.0;
+    Double targetY = 36.5;
+    SearchLocalDTO dto = SearchLocalDTO.builder()
+        .keyword(targetKeyword)
+        .latitudeY(targetY)
+        .longitudeX(targetX)
+        .memberId(1L)
+        .page(0)
+        .build();
+
+    // 클라이언트 호출 시 500 에러 시뮬레이션 - RuntimeException 던짐
+    when(kakaoLocalSearchClient.getLoocalsByKeyword(dto))
+        .thenThrow(new RuntimeException("Internal Server Error"));
+
+    // When & Then: 예외가 발생하는지 검증
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+      searchLocalService.getLocalInfoByKeyword(dto);
+    });
+
+    assertEquals("Internal Server Error", thrown.getMessage());
+
+    verify(kakaoLocalSearchClient, times(1)).getLoocalsByKeyword(dto);
   }
 }

--- a/src/test/java/org/example/honorsparkingbe/unit/service/SearchLoaclServiceTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/service/SearchLoaclServiceTest.java
@@ -1,0 +1,110 @@
+package org.example.honorsparkingbe.unit.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.PaginationResponse;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse.KakaoLocalDocument;
+import org.example.honorsparkingbe.dto.response.SearchLocalResponse.Meta;
+import org.example.honorsparkingbe.service.SearchLocalService;
+import org.example.honorsparkingbe.util.client.KakaoLocalSearchClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SearchLoaclServiceTest {
+
+  @InjectMocks
+  SearchLocalService searchLocalService;
+
+  @Mock
+  KakaoLocalSearchClient kakaoLocalSearchClient;
+
+  @Test
+  @DisplayName("키워드와 일치하는 로컬 데이터가 있을 때 page 0 요청 확인")
+  void keywordMatchedSuccessTestWithPage0() {
+    // Given
+    String targetKeyword = "cgv";
+    SearchLocalDTO dtoWithPage0 = SearchLocalDTO.builder()
+        .keyword(targetKeyword)
+        .latitudeY(36.5)
+        .longitudeX(127.0)
+        .memberId(1L)
+        .page(0)
+        .build();
+    SearchLocalDTO dtoWithPage1 = SearchLocalDTO.builder()
+        .keyword(targetKeyword)
+        .latitudeY(36.5)
+        .longitudeX(127.0)
+        .memberId(1L)
+        .page(0)
+        .build();
+
+    SearchLocalResponse mockKakaoLocalAPIRes = SearchLocalResponse.builder()
+        .meta(Meta.builder().isEnd(true).keyword(targetKeyword)
+            .pagination(PaginationResponse.builder()
+                .totalItems(2)
+                .pageSize(10)
+                .totalPages(1)
+                .currentPage(0)
+                .build())
+            .build())
+        .documents(List.of(
+            KakaoLocalDocument.builder()
+                .placeName("cgv 용산점")
+                .distance("123")
+                .categoryName("test category")
+                .addressName("test address")
+                .roadAddressName("test road address")
+                .y(35.5)
+                .x(127.3)
+                .build(),
+            KakaoLocalDocument.builder()
+                .placeName("cgv 이태원점")
+                .distance("123")
+                .categoryName("test category")
+                .addressName("test address")
+                .roadAddressName("test road address")
+                .y(35.5)
+                .x(127.3)
+                .build()))
+        .build();
+
+    // When
+    SearchLocalResponse resPage = searchLocalService.getLocalInfoByKeyword(dtoWithPage0);
+
+    // Then
+    assertEquals(targetKeyword, resPage.getMeta().getKeyword());
+    assertEquals(true, resPage.getMeta().getIsEnd());
+    assertEquals(10, resPage.getMeta().getPagination().getPageSize());
+    assertEquals(0, resPage.getMeta().getPagination().getCurrentPage());
+    assertEquals(1, resPage.getMeta().getPagination().getTotalPages());
+    assertEquals(2, resPage.getMeta().getPagination().getTotalItems());
+    assertEquals(2, resPage.getDocuments().size());
+    assertEquals(resPage.getDocuments().get(0), mockKakaoLocalAPIRes.getDocuments().get(0));
+    assertEquals(resPage.getDocuments().get(1), mockKakaoLocalAPIRes.getDocuments().get(1));
+  }
+
+  @Test
+  @DisplayName("키워드와 일치하는 로컬 데이터가 있을 때 page 1 요청 확인")
+  void keywordMatchedSuccessTestWithPage1() {
+  }
+
+  @Test
+  @DisplayName("키워드와 일치하는 로컬 데이터가 없을 때 확인")
+  void keywordMatchedFailTest() {
+
+  }
+
+  @Test
+  @DisplayName("카카오 클라이언트에서 에러가 났을 때 예외처리 확인")
+  void whenKakaoClientFailTest() {
+
+  }
+}

--- a/src/test/java/org/example/honorsparkingbe/unit/util/KakaoLocalSearchClientTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/KakaoLocalSearchClientTest.java
@@ -68,9 +68,9 @@ public class KakaoLocalSearchClientTest {
           } else if ("testKeyword2".equals(query) && "127.77".equals(x) && "36.55".equals(y)
               && page == null) {
             return jsonResponse(responseFor("testKeyword2"));
-          } else if ("testKeyword3".equals(query) && "127.77".equals(x) && "36.55".equals(y)
+          } else if ("테스트 키워드3".equals(query) && "127.77".equals(x) && "36.55".equals(y)
               && "2".equals(page)) {
-            return jsonResponse(responseFor("testKeyword3"));
+            return jsonResponse(responseFor("테스트 키워드3"));
           } else {
             return new MockResponse().setResponseCode(404);
           }
@@ -158,7 +158,7 @@ public class KakaoLocalSearchClientTest {
     // Given
     String testKeyword1 = "testKeyword1"; // 기본 키워드 검색 (쿼리만 있는 경우)
     String testKeyword2 = "testKeyword2"; // 키워드 + 좌표 (x, y)
-    String testKeyword3 = "testKeyword3"; // 키워드 + 좌표 + 페이지 (x, y, page)
+    String testKeyword3 = "테스트 키워드3"; // 키워드 + 좌표 + 페이지 (x, y, page)
 
     SearchLocalDTO dto1 = SearchLocalDTO.builder()
         .keyword(testKeyword1)

--- a/src/test/java/org/example/honorsparkingbe/unit/util/KakaoLocalSearchClientTest.java
+++ b/src/test/java/org/example/honorsparkingbe/unit/util/KakaoLocalSearchClientTest.java
@@ -1,0 +1,207 @@
+package org.example.honorsparkingbe.unit.util;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.constraints.NotNull;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.example.honorsparkingbe.dto.SearchLocalDTO;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse.Document;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse.Meta;
+import org.example.honorsparkingbe.dto.response.KakaoLocalClientResponse.SameName;
+import org.example.honorsparkingbe.util.client.KakaoLocalSearchClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class KakaoLocalSearchClientTest {
+
+  private static KakaoLocalSearchClient kakaoLocalSearchClient;
+  static MockWebServer mockWebServer;
+
+  private WebClient.Builder webClientBuilder;
+  private WebClient webClient;
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    mockWebServer = new MockWebServer();
+    // mockWebServer 세팅
+    mockWebServer.setDispatcher(new Dispatcher() {
+      @NotNull
+      @Override
+      public MockResponse dispatch(@NotNull RecordedRequest request) throws InterruptedException {
+        String path = request.getPath();
+        HttpUrl url = request.getRequestUrl();
+
+        String query = url.queryParameter("query");
+        String x = url.queryParameter("x");
+        String y = url.queryParameter("y");
+        String page = url.queryParameter("page");
+
+        if (query.equals("wrongKyeowrd")) {
+          return new MockResponse().setResponseCode(500).setBody("{\"error\":\"wrongKeyowrd\"}");
+        }
+
+        if (!path.contains("/search/keyword")) {
+          return new MockResponse().setResponseCode(404);
+        }
+
+        try {
+          if ("testKeyword1".equals(query) && x == null && y == null) {
+            return jsonResponse(responseFor("testKeyword1"));
+          } else if ("testKeyword2".equals(query) && "127.77".equals(x) && "36.55".equals(y)
+              && page == null) {
+            return jsonResponse(responseFor("testKeyword2"));
+          } else if ("testKeyword3".equals(query) && "127.77".equals(x) && "36.55".equals(y)
+              && "2".equals(page)) {
+            return jsonResponse(responseFor("testKeyword3"));
+          } else {
+            return new MockResponse().setResponseCode(404);
+          }
+        } catch (Exception e) {
+          System.out.println(e.getMessage());
+          return new MockResponse().setResponseCode(500).setBody("Internal Server Error");
+        }
+      }
+    });
+    mockWebServer.start(0); // available port 자동 할당
+    String mockBaseUrl = mockWebServer.url("/").toString();
+    System.out.println("Kakao Local Search API URL: " + mockBaseUrl);
+
+  }
+
+  @AfterAll
+  static void shutdownMockWebServer() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @BeforeEach
+  void setUpEach() {
+    String mockBaseUrl = mockWebServer.url("/").toString();
+    String mockApiKey = "test-api-key";
+    kakaoLocalSearchClient = new KakaoLocalSearchClient(mockApiKey, mockBaseUrl);
+  }
+
+
+  private static MockResponse jsonResponse(Object obj) throws IOException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return new MockResponse()
+        .setResponseCode(200)
+        .addHeader("Content-Type", "application/json")
+        .setBody(objectMapper.writeValueAsString(obj));
+  }
+
+  /**
+   * placeName인 keyWord만 담아서 Mock Response제작
+   *
+   * @param placeName
+   * @return
+   * @throws IOException
+   */
+  private static KakaoLocalClientResponse responseFor(String placeName) throws IOException {
+
+    KakaoLocalClientResponse res = KakaoLocalClientResponse
+        .builder()
+        .meta(Meta
+            .builder()
+            .sameName(SameName.builder()
+                .region(List.of())
+                .keyword(placeName)
+                .selectedRegion("")
+                .build())
+            .pageableCount(1)
+            .totalCount(1)
+            .isEnd(true)
+            .build()
+
+        )
+        .documents(List.of(
+            Document.builder()
+                .placeName(placeName + "강남점")
+                .distance("123")
+                .placeUrl("")
+                .categoryName(placeName + "category")
+                .addressName(placeName + "address")
+                .roadAddressName(placeName + "roadAddress")
+                .id("123123")
+                .phone("")
+                .categoryGroupCode("")
+                .categoryGroupName("")
+                .x("127.789")
+                .y("37.567")
+                .build()
+        ))
+        .build();
+
+    return res;
+  }
+
+  @Test
+  @DisplayName("keyword 올바른 Parm조건만 있을 때 Test")
+  void kakaoLocalSearchClientTest_When_Right_Parm() throws IOException {
+    // Given
+    String testKeyword1 = "testKeyword1"; // 기본 키워드 검색 (쿼리만 있는 경우)
+    String testKeyword2 = "testKeyword2"; // 키워드 + 좌표 (x, y)
+    String testKeyword3 = "testKeyword3"; // 키워드 + 좌표 + 페이지 (x, y, page)
+
+    SearchLocalDTO dto1 = SearchLocalDTO.builder()
+        .keyword(testKeyword1)
+        .build();
+    SearchLocalDTO dto2 = SearchLocalDTO.builder()
+        .keyword(testKeyword2)
+        .latitudeY(36.55)
+        .longitudeX(127.77)
+        .build();
+    SearchLocalDTO dto3 = SearchLocalDTO.builder()
+        .keyword(testKeyword3)
+        .latitudeY(36.55)
+        .longitudeX(127.77)
+        .page(1)
+        .build();
+
+    KakaoLocalClientResponse expectRes1 = responseFor(testKeyword1);
+    KakaoLocalClientResponse expectRes2 = responseFor(testKeyword2);
+    KakaoLocalClientResponse expectRes3 = responseFor(testKeyword3);
+
+    KakaoLocalClientResponse res1 = kakaoLocalSearchClient.getLoocalsByKeyword(dto1);
+    KakaoLocalClientResponse res2 = kakaoLocalSearchClient.getLoocalsByKeyword(dto2);
+    KakaoLocalClientResponse res3 = kakaoLocalSearchClient.getLoocalsByKeyword(dto3);
+
+    assertEquals(res1, expectRes1);
+    assertEquals(res2, expectRes2);
+    assertEquals(res3, expectRes3);
+  }
+
+  @Test
+  @DisplayName("client가 요청에 실패했을 때 500에러 잘 던지는지 확인")
+  void kakaoLocalSearchClientTest_When_Error_Occured() throws IOException {
+    // Given
+    String wrongKyeowrd = "wrongKyeowrd"; // 기본 키워드 검색 (쿼리만 있는 경우)
+
+    SearchLocalDTO dto = SearchLocalDTO.builder()
+        .keyword(wrongKyeowrd)
+        .build();
+
+    // When & Then
+    assertThrows(RuntimeException.class, () -> {
+      kakaoLocalSearchClient.getLoocalsByKeyword(dto); // 여기서 예외가 발생하길 기대
+    });
+  }
+
+}


### PR DESCRIPTION
# 1. 로컬 검색 기능 완료
Kakao Open API 를 활용해 검색 API 개발을 완료했습니다.

# 2. Web client와 MockWebServer

카카오 서버와의 통신용 클라이언트를 `WebClient`를 사용했습니다.
또 외부 API를 테스팅하기위해 가상의 웹서버를 만드는 `MockWebServer`를 활용해줬습니다.

나중에 외부 API 연동 테스트코드 짤 때 `MockWebServer`를 하면 클라이언트의 모킹이 정말 쉬워집니다..!!(사실상 간접 모킹)
참고 하시길 바랍니다..!!